### PR TITLE
stream subscribton restoring and unsubscribe alias

### DIFF
--- a/src/stream/base.ts
+++ b/src/stream/base.ts
@@ -3,12 +3,7 @@
  */
 import { on, EventEmitter } from 'node:events';
 import { TinkoffInvestApi } from '../api.js';
-
-type EventMap<Res> = {
-  data: (data: Res) => unknown,
-  close: () => unknown,
-  error: (e: Error) => unknown, // todo
-}
+import { EventMap, StreamEvents } from './events.js';
 
 export abstract class BaseStream<Req, Res> {
   connected = false;
@@ -59,10 +54,10 @@ export abstract class BaseStream<Req, Res> {
   protected async loop(call: AsyncIterable<Res>) {
     this.connected = true;
     for await (const data of call) {
-      this.emitter.emit('data', data);
+      this.emitter.emit(StreamEvents.data, data);
     }
     // Если вышли из цикла, значит соединение разорвано
     this.connected = false;
-    this.emitter.emit('close');
+    this.emitter.emit(StreamEvents.close);
   }
 }

--- a/src/stream/events.ts
+++ b/src/stream/events.ts
@@ -1,0 +1,13 @@
+export const enum StreamEvents {
+  data = 'data',
+  close = 'close',
+  error = 'error',
+  restore = 'restore',
+}
+
+export type EventMap<Res> = {
+  [StreamEvents.data]: (data: Res) => unknown,
+  [StreamEvents.close]: () => unknown,
+  [StreamEvents.error]: (e: Error) => unknown, // todo
+  [StreamEvents.restore]: () => unknown, // todo
+}

--- a/src/stream/market.ts
+++ b/src/stream/market.ts
@@ -87,6 +87,7 @@ export class MarketStream extends BaseStream<MarketDataRequest, MarketDataRespon
   protected restoreSubscribe = () => {
     this.subscribers.forEach((request: MarketDataWatch) => {
         this.watch(request);
+        this.emitter.emit(StreamEvents.restore);
     });
   };
 }

--- a/src/stream/market.ts
+++ b/src/stream/market.ts
@@ -85,9 +85,13 @@ export class MarketStream extends BaseStream<MarketDataRequest, MarketDataRespon
    * Восстановление подписок маркет стримов
    */
   protected restoreSubscribe = () => {
+    if (!this.subscribers.size) {
+      return;
+    }
+
+    this.emitter.emit(StreamEvents.restore);
     this.subscribers.forEach((request: MarketDataWatch) => {
         this.watch(request);
-        this.emitter.emit(StreamEvents.restore);
     });
   };
 }

--- a/src/stream/market.ts
+++ b/src/stream/market.ts
@@ -4,6 +4,8 @@
  */
 import { BaseStream } from './base.js';
 import { MarketDataRequest, MarketDataResponse, SubscriptionAction } from '../generated/marketdata.js';
+import type { TinkoffInvestApi } from '../api.js';
+import { StreamEvents } from './events.js';
 
 type MarketDataWatch = {
   candles?: Required<MarketDataRequest>['subscribeCandlesRequest']['instruments'],
@@ -19,22 +21,44 @@ type MarketDataWatch = {
 // }
 
 export class MarketStream extends BaseStream<MarketDataRequest, MarketDataResponse> {
+
+  /**
+   * Список активных подписок
+   */
+  private subscribers = new Set<MarketDataWatch>();
+
+  constructor(public api: TinkoffInvestApi) {
+    super(api);
+
+    this.emitter.on(StreamEvents.close, this.restoreSubscribe);
+  }
+
   /**
    * Подписаться на обновления.
    */
   watch(request: MarketDataWatch) {
     this.ensureConnected();
     this.createSubscription(request, SubscriptionAction.SUBSCRIPTION_ACTION_SUBSCRIBE);
+    this.subscribers.add(request);
+
+    return () => {
+      this.unwatch(request);
+    };
   }
 
   /**
-   * Отписаться от обновлений.
+   * Отписаться от обновлений в ручном режиме
+   * NB!: Для безопасной отписки можно использовать возвращаемую функцию из метода `this.watch`
    */
   unwatch(request: MarketDataWatch) {
     this.ensureConnected();
     this.createSubscription(request, SubscriptionAction.SUBSCRIPTION_ACTION_UNSUBSCRIBE);
+    this.subscribers.delete(request);
   }
 
+  /**
+   * Подключитсья при необходимости
+   */
   protected ensureConnected() {
     if (!this.connected) {
       const req = this.createRequestIterable();
@@ -43,6 +67,9 @@ export class MarketStream extends BaseStream<MarketDataRequest, MarketDataRespon
     }
   }
 
+  /**
+   * Создание подписки
+   */
   protected createSubscription(request: MarketDataWatch, subscriptionAction: SubscriptionAction) {
     const keys = Object.keys(request) as (keyof MarketDataWatch)[];
     keys.forEach(key => {
@@ -53,6 +80,15 @@ export class MarketStream extends BaseStream<MarketDataRequest, MarketDataRespon
       this.sendSubscriptionRequest({ [reqKey]: { subscriptionAction, instruments } });
     });
   }
+
+  /**
+   * Восстановление подписок маркет стримов
+   */
+  protected restoreSubscribe = () => {
+    this.subscribers.forEach((request: MarketDataWatch) => {
+        this.watch(request);
+    });
+  };
 }
 
 function capitalize(s: string) {


### PR DESCRIPTION
Восстановление подписок при потери соединения и небольшой рефакторинг ивентов для #4 

Сейчас использование стало немного удобнее.
```typescript
const unsubscribeListener = this.api.stream.market.on('data', ({ candle }) => {
    // Tinkoff each new subscribtion affect others and call all subscribed callbacks, because all data used one connection
    // This mean we nedd to validate figi for each candle
    if (candle && candle.figi === figi) {
        handler(transformTinkoffCandle(candle));
    }
});

const request = { candles: [{ figi, interval }] };
const unsubscribeStream = this.api.stream.market.watch(request);

return () => {
    this.removeInstrumentFromCache(opts);
    unsubscribeListener();
    unsubscribeStream();
};

```