### PR TITLE
Stream by figi and auto-reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ api.stream.market.watch({ candles: [
 // обработка событий
 api.stream.market.on('data', data => console.log('stream data', data));
 api.stream.market.on('error', error => console.log('stream error', error));
-api.stream.market.on('close', reason => console.log('stream closed', reason));
+api.stream.market.on('close', error => console.log('stream closed, reason:', error));
 
 // закрыть соединение через 3 сек
 setTimeout(() => api.stream.market.cancel(), 3000);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinkoff-invest-api",
-  "version": "5.0.0-0",
+  "version": "5.0.0-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tinkoff-invest-api",
-      "version": "5.0.0-0",
+      "version": "5.0.0-1",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinkoff-invest-api",
-  "version": "4.1.0",
+  "version": "5.0.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tinkoff-invest-api",
-      "version": "4.1.0",
+      "version": "5.0.0-0",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "long": "^4.0.0",
         "ms": "^3.0.0-beta.2",
         "nice-grpc": "^1.2.0",
-        "protobufjs": "^6.11.3"
+        "protobufjs": "^6.11.3",
+        "typed-emitter": "^2.1.0"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -31,7 +32,6 @@
         "np": "^7.6.0",
         "ts-node": "^10.8.1",
         "ts-proto": "^1.115.4",
-        "typed-emitter": "^2.1.0",
         "typescript": "^4.7.3"
       }
     },
@@ -6332,7 +6332,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
       "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -6899,7 +6899,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -6950,7 +6950,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
       "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "dev": true,
       "optionalDependencies": {
         "rxjs": "*"
       }
@@ -12082,7 +12081,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
       "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -12504,7 +12503,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "devOptional": true
     },
     "tsutils": {
       "version": "3.21.0",
@@ -12542,7 +12541,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
       "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "dev": true,
       "requires": {
         "rxjs": "*"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinkoff-invest-api",
   "description": "Node.js SDK for Tinkoff Invest API",
-  "version": "5.0.0-0",
+  "version": "5.0.0-1",
   "type": "module",
   "main": "./cjs/index.js",
   "module": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinkoff-invest-api",
   "description": "Node.js SDK for Tinkoff Invest API",
-  "version": "4.1.0",
+  "version": "5.0.0-0",
   "type": "module",
   "main": "./cjs/index.js",
   "module": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "long": "^4.0.0",
     "ms": "^3.0.0-beta.2",
     "nice-grpc": "^1.2.0",
-    "protobufjs": "^6.11.3"
+    "protobufjs": "^6.11.3",
+    "typed-emitter": "^2.1.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
@@ -53,7 +54,6 @@
     "np": "^7.6.0",
     "ts-node": "^10.8.1",
     "ts-proto": "^1.115.4",
-    "typed-emitter": "^2.1.0",
     "typescript": "^4.7.3"
   },
   "author": "Vitaliy Potapov",

--- a/src/stream/market-subscription.ts
+++ b/src/stream/market-subscription.ts
@@ -1,0 +1,110 @@
+/**
+ * Класс подписки в стриме market.
+ * Позволяет ожидать результата подписки и вызывать обработчики для figi, заданных при подписке.
+ * See: https://github.com/vitalets/tinkoff-invest-api/issues/6
+ */
+import {
+  Candle,
+  CandleSubscription,
+  InfoSubscription,
+  LastPrice,
+  LastPriceSubscription,
+  MarketDataRequest,
+  MarketDataResponse,
+  OrderBook,
+  OrderBookSubscription,
+  SubscriptionAction,
+  SubscriptionStatus,
+  Trade,
+  TradeSubscription,
+  TradingStatus
+} from '../generated/marketdata.js';
+
+type ResponseSubscription = CandleSubscription
+  | TradeSubscription
+  | OrderBookSubscription
+  | LastPriceSubscription
+  | InfoSubscription;
+type ResponseData = Candle | Trade | OrderBook | LastPrice | TradingStatus;
+
+type MarketSubscriptionOptions<S, D> = {
+  buildRequest: (subscriptionAction: SubscriptionAction) => MarketDataRequest,
+  buildResponse: (res: MarketDataResponse) => UniversalMarketResponse<S, D>,
+  dataHandler: (data: D) => unknown,
+  requestKeys: string[],
+}
+
+/**
+ * Универсальный ответ (одинаковые поля для разных типов подписок)
+ */
+export type UniversalMarketResponse<S, D> = {
+  trackingId?: string;
+  subscriptions?: S[];
+  // ключи в статусе подписки, по которым определяем, что статус для нужного запроса подписки
+  subscriptionKeys?: string[];
+  data?: D;
+  // ключ данных в ответе, по которому определяем, что данные для нужного обработчика
+  dataKey?: string;
+}
+
+export class MarketSubscription<S extends ResponseSubscription, D extends ResponseData> {
+  protected waitingStatusResolve?: () => unknown;
+  protected waitingStatusReject?: (error: Error) => unknown;
+
+  constructor(protected options: MarketSubscriptionOptions<S, D>) {
+    this.handler = this.handler.bind(this);
+  }
+
+  getRequest(subscriptionAction: SubscriptionAction) {
+    return this.options.buildRequest(subscriptionAction);
+  }
+
+  handler(res: MarketDataResponse) {
+    const uniRes = this.options.buildResponse(res);
+    this.statusHandler(uniRes);
+    this.dataHandler(uniRes);
+  }
+
+  async waitStatus() {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        this.waitingStatusResolve = resolve;
+        this.waitingStatusReject = reject;
+      });
+    } finally {
+      this.waitingStatusResolve = undefined;
+      this.waitingStatusReject = undefined;
+    }
+  }
+
+  // eslint-disable-next-line complexity
+  protected statusHandler({ subscriptions, subscriptionKeys, trackingId }: UniversalMarketResponse<S, D>) {
+    if (!this.waitingStatusResolve || !this.waitingStatusReject) return;
+    if (!subscriptions || !subscriptionKeys) return;
+    if (subscriptionKeys.sort().join() !== this.options.requestKeys.sort().join()) return;
+    const errorSubscriptions = subscriptions
+      .filter(s => s.subscriptionStatus !== SubscriptionStatus.SUBSCRIPTION_STATUS_SUCCESS);
+    if (errorSubscriptions.length) {
+      const error = this.buildSubscriptionError(errorSubscriptions, trackingId);
+      this.waitingStatusReject(error);
+    } else {
+      this.waitingStatusResolve();
+    }
+  }
+
+  protected dataHandler({ data, dataKey }: UniversalMarketResponse<S, D>) {
+    if (!data || !dataKey) return;
+    if (this.options.requestKeys.includes(dataKey)) {
+      this.options.dataHandler(data);
+    }
+  }
+
+  protected buildSubscriptionError(errorSubscriptions: S[], trackingId?: string) {
+    const lines = errorSubscriptions.map(s => `${s.figi}: status ${s.subscriptionStatus}`);
+    return new Error([
+      'Subscription error:',
+      ...lines,
+      `TrackingId: ${trackingId}`,
+    ].join('\n'));
+  }
+}

--- a/src/stream/market-subscription.ts
+++ b/src/stream/market-subscription.ts
@@ -31,6 +31,7 @@ type MarketSubscriptionOptions<S, D> = {
   buildRequest: (subscriptionAction: SubscriptionAction) => MarketDataRequest,
   buildResponse: (res: MarketDataResponse) => UniversalMarketResponse<S, D>,
   dataHandler: (data: D) => unknown,
+  // массив ключей под данным в запросе (по ним матчим ответы на нужный обработчик)
   requestKeys: string[],
 }
 
@@ -40,7 +41,7 @@ type MarketSubscriptionOptions<S, D> = {
 export type UniversalMarketResponse<S, D> = {
   trackingId?: string;
   subscriptions?: S[];
-  // ключи в статусе подписки, по которым определяем, что статус для нужного запроса подписки
+  // ключи в статусе подписки, по которым определяем, что статус для нужного запроса
   subscriptionKeys?: string[];
   data?: D;
   // ключ данных в ответе, по которому определяем, что данные для нужного обработчика

--- a/src/stream/market.ts
+++ b/src/stream/market.ts
@@ -3,58 +3,207 @@
  * See: https://tinkoff.github.io/investAPI/marketdata/#marketdataservice
  */
 import { BaseStream } from './base.js';
-import { MarketDataRequest, MarketDataResponse, SubscriptionAction } from '../generated/marketdata.js';
+import { MarketSubscription } from './market-subscription.js';
+import {
+  Candle,
+  CandleInstrument,
+  CandleSubscription,
+  InfoInstrument,
+  InfoSubscription,
+  LastPrice,
+  LastPriceInstrument,
+  LastPriceSubscription,
+  MarketDataRequest,
+  MarketDataResponse,
+  OrderBook,
+  OrderBookInstrument,
+  OrderBookSubscription,
+  SubscribeCandlesRequest,
+  SubscribeInfoRequest,
+  SubscribeLastPriceRequest,
+  SubscribeOrderBookRequest,
+  SubscribeTradesRequest,
+  SubscriptionAction,
+  Trade,
+  TradeInstrument,
+  TradeSubscription,
+  TradingStatus
+} from '../generated/marketdata.js';
+import { TinkoffInvestApi } from '../api.js';
 
-type MarketDataWatch = {
-  candles?: Required<MarketDataRequest>['subscribeCandlesRequest']['instruments'],
-  orderBook?: Required<MarketDataRequest>['subscribeOrderBookRequest']['instruments'],
-  trades?: Required<MarketDataRequest>['subscribeTradesRequest']['instruments'],
-  info?: Required<MarketDataRequest>['subscribeInfoRequest']['instruments'],
-  lastPrice?: Required<MarketDataRequest>['subscribeLastPriceRequest']['instruments'],
-}
-
-// todo: support unwatch 'all'
-// type MarketDataUnwatch = {
-//   [K in keyof MarketDataWatch]: MarketDataWatch[K] | 'all'
-// }
+type SubscribeRequest = Required<MarketDataRequest>[keyof MarketDataRequest];
+type WithoutAction<T extends SubscribeRequest> = Omit<T, 'subscriptionAction'>
 
 export class MarketStream extends BaseStream<MarketDataRequest, MarketDataResponse> {
-  /**
-   * Подписаться на обновления.
-   */
-  watch(request: MarketDataWatch) {
-    this.ensureConnected();
-    this.createSubscription(request, SubscriptionAction.SUBSCRIPTION_ACTION_SUBSCRIBE);
+  options = {
+    autoReconnect: true,
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  subscriptions = new Set<MarketSubscription<any, any>>();
+
+  constructor(public api: TinkoffInvestApi) {
+    super(api);
+    this.emitter.on('close', error => this.onClose(error));
   }
 
   /**
-   * Отписаться от обновлений.
+   * Подписка на свечи.
    */
-  unwatch(request: MarketDataWatch) {
-    this.ensureConnected();
-    this.createSubscription(request, SubscriptionAction.SUBSCRIPTION_ACTION_UNSUBSCRIBE);
+  async candles(req: WithoutAction<SubscribeCandlesRequest>, dataHandler: (candle: Candle) => unknown) {
+    const getKey = ({ figi, interval }: CandleInstrument | CandleSubscription | Candle) => `${figi}_${interval}`;
+    const subscription = new MarketSubscription<CandleSubscription, Candle>({
+      requestKeys: req.instruments.map(getKey),
+      dataHandler,
+      buildRequest: subscriptionAction => ({ subscribeCandlesRequest: { subscriptionAction, ...req }}),
+      buildResponse: ({ candle, subscribeCandlesResponse }) => {
+        const { trackingId, candlesSubscriptions: subscriptions } = subscribeCandlesResponse || {};
+        return {
+          trackingId,
+          subscriptions,
+          subscriptionKeys: subscriptions && subscriptions.map(getKey),
+          data: candle,
+          dataKey: candle && getKey(candle),
+        };
+      },
+    });
+    return this.watch(subscription);
+  }
+
+  /**
+   * Подписка на сделки.
+   */
+  async trades(req: WithoutAction<SubscribeTradesRequest>, dataHandler: (trade: Trade) => unknown) {
+    const getKey = ({ figi }: TradeInstrument | TradeSubscription | Trade) => figi;
+    const subscription = new MarketSubscription<TradeSubscription, Trade>({
+      requestKeys: req.instruments.map(getKey),
+      dataHandler,
+      buildRequest: subscriptionAction => ({ subscribeTradesRequest: { subscriptionAction, ...req }}),
+      buildResponse: ({ trade, subscribeTradesResponse }) => {
+        const { trackingId, tradeSubscriptions: subscriptions } = subscribeTradesResponse || {};
+        return {
+          trackingId,
+          subscriptions,
+          subscriptionKeys: subscriptions && subscriptions.map(getKey),
+          data: trade,
+          dataKey: trade && getKey(trade),
+        };
+      },
+    });
+    return this.watch(subscription);
+  }
+
+  /**
+   * Подписка на стакан.
+   */
+   async orderBook(req: WithoutAction<SubscribeOrderBookRequest>, dataHandler: (orderbook: OrderBook) => unknown) {
+    const getKey = ({ figi, depth }: OrderBookInstrument | OrderBookSubscription | OrderBook) => `${figi}_${depth}`;
+    const subscription = new MarketSubscription<OrderBookSubscription, OrderBook>({
+      requestKeys: req.instruments.map(getKey),
+      dataHandler,
+      buildRequest: subscriptionAction => ({ subscribeOrderBookRequest: { subscriptionAction, ...req }}),
+      buildResponse: ({ orderbook, subscribeOrderBookResponse }) => {
+        const { trackingId, orderBookSubscriptions: subscriptions } = subscribeOrderBookResponse || {};
+        return {
+          trackingId,
+          subscriptions,
+          subscriptionKeys: subscriptions && subscriptions.map(getKey),
+          data: orderbook,
+          dataKey: orderbook && getKey(orderbook),
+        };
+      },
+    });
+    return this.watch(subscription);
+  }
+
+  /**
+   * Подписка на цены.
+   */
+   async lastPrice(req: WithoutAction<SubscribeLastPriceRequest>, dataHandler: (lastPrice: LastPrice) => unknown) {
+    const getKey = ({ figi }: LastPriceInstrument | LastPriceSubscription | LastPrice) => figi;
+    const subscription = new MarketSubscription<LastPriceSubscription, LastPrice>({
+      requestKeys: req.instruments.map(getKey),
+      dataHandler,
+      buildRequest: subscriptionAction => ({ subscribeLastPriceRequest: { subscriptionAction, ...req }}),
+      buildResponse: ({ lastPrice, subscribeLastPriceResponse }) => {
+        const { trackingId, lastPriceSubscriptions: subscriptions } = subscribeLastPriceResponse || {};
+        return {
+          trackingId,
+          subscriptions,
+          subscriptionKeys: subscriptions && subscriptions.map(getKey),
+          data: lastPrice,
+          dataKey: lastPrice && getKey(lastPrice),
+        };
+      },
+    });
+    return this.watch(subscription);
+  }
+
+  /**
+   * Подписка на информацию об инструменте.
+   */
+   async info(req: WithoutAction<SubscribeInfoRequest>, dataHandler: (tradingStatus: TradingStatus) => unknown) {
+    const getKey = ({ figi }: InfoInstrument | InfoSubscription | TradingStatus) => figi;
+    const subscription = new MarketSubscription<InfoSubscription, TradingStatus>({
+      requestKeys: req.instruments.map(getKey),
+      dataHandler,
+      buildRequest: subscriptionAction => ({ subscribeInfoRequest: { subscriptionAction, ...req }}),
+      buildResponse: ({ tradingStatus, subscribeInfoResponse }) => {
+        const { trackingId, infoSubscriptions: subscriptions } = subscribeInfoResponse || {};
+        return {
+          trackingId,
+          subscriptions,
+          subscriptionKeys: subscriptions && subscriptions.map(getKey),
+          data: tradingStatus,
+          dataKey: tradingStatus && getKey(tradingStatus),
+        };
+      },
+    });
+    return this.watch(subscription);
+  }
+
+  async reconnect() {
+    // todo: check that subscription listeners removed (to avoid duplicate listeners)
+    for (const subscription of this.subscriptions) {
+      await this.watch(subscription);
+    }
   }
 
   protected ensureConnected() {
     if (!this.connected) {
       const req = this.createRequestIterable();
       const call = this.api.marketdataStream.marketDataStream(req);
-      this.loop(call);
+      this.waitEvents(call);
     }
   }
 
-  protected createSubscription(request: MarketDataWatch, subscriptionAction: SubscriptionAction) {
-    const keys = Object.keys(request) as (keyof MarketDataWatch)[];
-    keys.forEach(key => {
-      const capitalKey = capitalize(key) as Capitalize<typeof key>;
-      const reqKey: keyof MarketDataRequest = `subscribe${capitalKey}Request`;
-      const instruments = request[key];
-      // todo: better type check
-      this.sendSubscriptionRequest({ [reqKey]: { subscriptionAction, instruments } });
-    });
+  protected onClose(error?: Error) {
+    this.subscriptions.forEach(subscription => this.off('data', subscription.handler));
+    if (error && this.options.autoReconnect) {
+      // todo: use exponential backoff
+      this.reconnect();
+    }
   }
-}
 
-function capitalize(s: string) {
-  return s.charAt(0).toUpperCase() + s.slice(1);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected async watch(subscription: MarketSubscription<any, any>) {
+    this.ensureConnected();
+    this.sendRequest(subscription.getRequest(SubscriptionAction.SUBSCRIPTION_ACTION_SUBSCRIBE));
+    this.on('data', subscription.handler);
+    try {
+      await subscription.waitStatus();
+    } catch (e) {
+      this.off('data', subscription.handler);
+      throw e;
+    }
+    this.subscriptions.add(subscription);
+    return () => this.unwatch(subscription);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected async unwatch(subscription: MarketSubscription<any, any>) {
+    this.sendRequest(subscription.getRequest(SubscriptionAction.SUBSCRIPTION_ACTION_UNSUBSCRIBE));
+    await subscription.waitStatus();
+    this.off('data', subscription.handler);
+    this.subscriptions.delete(subscription);
+  }
 }

--- a/src/stream/trades.ts
+++ b/src/stream/trades.ts
@@ -12,7 +12,7 @@ export class TradesStream extends BaseStream<TradesStreamRequest, TradesStreamRe
   watch(request: TradesStreamRequest) {
     // тут работает немного по-другому, т.к. request не AsyncIterable
     const call = this.api.ordersStream.tradesStream(request);
-    this.loop(call);
+    this.waitEvents(call);
   }
 
   // todo: cancel() - тут отмена работает по-другому, т.к. req не AsyncIterable

--- a/test/specs/stream.spec.ts
+++ b/test/specs/stream.spec.ts
@@ -1,69 +1,181 @@
-import { MarketDataResponse, SubscriptionInterval } from '../../src/generated/marketdata.js';
+import EventEmitter, { on } from 'node:events';
+import { Candle, MarketDataResponse, SubscriptionInterval, SubscriptionStatus } from '../../src/generated/marketdata.js';
 import { MarketStream } from '../../src/stream/market.js';
-
-export async function waitMarketStreamEvent(stream: MarketStream, event: 'open' | 'data' | 'close' | 'error') {
-  return new Promise<MarketDataResponse>(resolve => stream.on(event, resolve));
-}
 
 describe('stream', () => {
 
   const figi = 'BBG004730N88';
   const interval = SubscriptionInterval.SUBSCRIPTION_INTERVAL_ONE_MINUTE;
+  const waitingClose = false;
+  const candlesReq = { instruments: [ { figi, interval } ], waitingClose };
+  const handler = () => {}; // eslint-disable-line @typescript-eslint/no-empty-function
+  const candlesStatus: MarketDataResponse = {
+    subscribeCandlesResponse: {
+      trackingId: 'xxx',
+      candlesSubscriptions: [
+        { figi, interval, subscriptionStatus: SubscriptionStatus.SUBSCRIPTION_STATUS_SUCCESS }
+      ]
+    }
+  };
 
-  after(() => {
-    testApi.stream.market.cancel();
+  beforeEach(() => {
+    // отключаем autoReconnect, чтобы проще тестировать
+    testApi.stream.market.options.autoReconnect = false;
+    testApi.stream.market.subscriptions.clear();
   });
 
-  it('подписка на свечи', async () => {
+  afterEach(async () => {
+    await testApi.stream.market.cancel();
+  });
+
+  it('подписка на свечи по конкретным figi', async () => {
+    const calls: Candle[] = [];
+    const stream = new MarketStreamEmulate(testApi);
+
+    await Promise.all([
+      stream.candles(candlesReq, candle => calls.push(candle)),
+      stream.emulate(candlesStatus),
+    ]);
+
+    // нужный figi и interval
+    const ownFigiAndInterval = { candle: { figi, interval, volume: 1 }};
+    await Promise.all([ stream.emulate(ownFigiAndInterval), waitMarketStreamEvent(stream, 'data') ]);
+
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0], { figi, interval, volume: 1 });
+
+    // другой figi
+    const anotherFigi = { candle: { figi: 'another_figi', interval, volume: 2 }};
+    await Promise.all([ stream.emulate(anotherFigi), waitMarketStreamEvent(stream, 'data') ]);
+
+    // другой interval
+    const anotherInterval = { candle: { figi, interval: 2, volume: 3 }};
+    await Promise.all([ stream.emulate(anotherInterval), waitMarketStreamEvent(stream, 'data') ]);
+
+    assert.equal(calls.length, 1);
+  });
+
+  it('ошибка подписки (неверный figi)', async () => {
+    const promise = testApi.stream.market.candles({
+      instruments: [ { figi: 'bad_figi', interval } ],
+      waitingClose,
+    }, handler);
+    await assert.rejects(promise, /bad_figi: status 2/);
+  });
+
+  it('события: open, data, close', async () => {
     const openPromise = waitMarketStreamEvent(testApi.stream.market, 'open');
-    testApi.stream.market.watch({ candles: [ { figi, interval } ]});
+    const dataPromise = waitMarketStreamEvent(testApi.stream.market, 'data');
+    const closePromise = waitMarketStreamEvent(testApi.stream.market, 'close');
+    await testApi.stream.market.candles(candlesReq, handler);
     await openPromise;
-    const data = await waitMarketStreamEvent(testApi.stream.market, 'data');
+    const data = await dataPromise;
+    await testApi.stream.market.cancel();
+    const closeError = await closePromise;
     assert.deepEqual(data.subscribeCandlesResponse?.candlesSubscriptions, [
       { figi, interval: 1, subscriptionStatus: 1 }
     ]);
-  });
-
-  it('подписка: неверный figi - ошибки нет, subscriptionStatus в ответе = 2', async () => {
-    testApi.stream.market.watch({ candles: [{ figi: 'bad figi', interval }]});
-    const data = await waitMarketStreamEvent(testApi.stream.market, 'data');
-    assert.deepEqual(data.subscribeCandlesResponse?.candlesSubscriptions, [
-      { figi: 'bad figi', interval: 1, subscriptionStatus: 2 }
-    ]);
-  });
-
-  it('close', async () => {
-    testApi.stream.market.watch({ candles: [ { figi, interval } ]});
-    await waitMarketStreamEvent(testApi.stream.market, 'data');
-    assert.equal(testApi.stream.market.connected, true);
-    const promise = waitMarketStreamEvent(testApi.stream.market, 'close');
-    testApi.stream.market.cancel();
-    const reason = await promise;
     assert.equal(testApi.stream.market.connected, false);
-    assert.equal(reason, undefined);
+    assert.equal(closeError, undefined);
   });
 
-  it('error', async () => {
-    class MarketStreamTest extends MarketStream {
-      protected async loop() {
-        // emulate stream that throws error
-        // eslint-disable-next-line require-yield
-        const call = { async *[Symbol.asyncIterator]() { throw new Error('foo'); } };
-        await super.loop(call);
-      }
-    }
+  it('connected', async () => {
+    assert.equal(testApi.stream.market.connected, false);
+    await testApi.stream.market.candles(candlesReq, handler);
+    assert.equal(testApi.stream.market.connected, true);
+    await testApi.stream.market.cancel();
+    assert.equal(testApi.stream.market.connected, false);
+  });
 
-    const stream = new MarketStreamTest(testApi);
+  it('unsubscribe', async () => {
+    assert.equal(testApi.stream.market.subscriptions.size, 0);
+    const unsubscribe = await testApi.stream.market.candles(candlesReq, handler);
+    assert.equal(testApi.stream.market.subscriptions.size, 1);
+    await unsubscribe();
+    assert.equal(testApi.stream.market.subscriptions.size, 0);
+  });
 
-    const errorPromise = waitMarketStreamEvent(stream, 'error');
-    const closePromise = waitMarketStreamEvent(stream, 'close');
+  it('закрытие соединения при ошибке сервера', async () => {
+    const stream = new MarketStreamEmulate(testApi);
+    stream.options.autoReconnect = false;
 
-    stream.watch({ candles: [{ figi, interval } ]});
+    await Promise.all([
+      stream.candles(candlesReq, handler),
+      stream.emulate(candlesStatus),
+    ]);
 
-    const [ error, reason ] = await Promise.all([ errorPromise, closePromise ]);
+    const [ error, closeError ] = await Promise.all([
+      waitMarketStreamEvent(stream, 'error'),
+      waitMarketStreamEvent(stream, 'close'),
+      stream.emulate(new Error('foo')),
+    ]);
 
     assert.equal(stream.connected, false);
     assert.equal(error.toString(), 'Error: foo');
-    assert.equal(reason.toString(), 'Error: foo');
+    assert.equal(closeError.toString(), 'Error: foo');
+  });
+
+  it('autoReconnect', async () => {
+    const stream = new MarketStreamEmulate(testApi);
+    stream.options.autoReconnect = true;
+
+    await Promise.all([
+      stream.candles(candlesReq, handler),
+      stream.emulate(candlesStatus),
+    ]);
+
+    await Promise.all([
+      waitMarketStreamEvent(stream, 'error'),
+      waitMarketStreamEvent(stream, 'close'),
+      waitMarketStreamEvent(stream, 'open'),
+      stream.emulate(new Error('foo')),
+    ]);
+
+    await Promise.all([
+      waitMarketStreamEvent(stream, 'data'),
+      stream.emulate(candlesStatus),
+    ]);
+
+    assert.equal(stream.connected, true);
+    assert.equal(stream.getEmitter().listenerCount('data'), 1);
   });
 });
+
+export async function waitMarketStreamEvent(stream: MarketStream, event: 'open' | 'data' | 'close' | 'error') {
+  return new Promise<MarketDataResponse>(resolve => {
+    const handler = (res: MarketDataResponse) => {
+      stream.off(event, handler);
+      resolve(res);
+    };
+    stream.on(event, handler);
+  });
+}
+
+/**
+ * Класс, позволяющий эмулировать ответы сервера
+ */
+class MarketStreamEmulate extends MarketStream {
+  private responseEmitter = new EventEmitter();
+
+  emulate(res: MarketDataResponse | Error) {
+    this.responseEmitter.emit('response', res);
+  }
+
+  getEmitter() {
+    return this.emitter;
+  }
+
+  protected async waitEvents() {
+    const call = this.createResponseIterable();
+    await super.waitEvents(call);
+  }
+
+  protected async *createResponseIterable() {
+    const innerRes = on(this.responseEmitter, 'response');
+    for await (const data of innerRes) {
+      const value = data[ 0 ];
+      if (value instanceof Error) throw value;
+      yield value as MarketDataResponse;
+    }
+  }
+}

--- a/test/specs/stream.spec.ts
+++ b/test/specs/stream.spec.ts
@@ -1,7 +1,7 @@
 import { MarketDataResponse, SubscriptionInterval } from '../../src/generated/marketdata.js';
 import { MarketStream } from '../../src/stream/market.js';
 
-export async function waitMarketStreamEvent(stream: MarketStream, event: 'data' | 'close' | 'error') {
+export async function waitMarketStreamEvent(stream: MarketStream, event: 'open' | 'data' | 'close' | 'error') {
   return new Promise<MarketDataResponse>(resolve => stream.on(event, resolve));
 }
 
@@ -15,7 +15,9 @@ describe('stream', () => {
   });
 
   it('подписка на свечи', async () => {
+    const openPromise = waitMarketStreamEvent(testApi.stream.market, 'open');
     testApi.stream.market.watch({ candles: [ { figi, interval } ]});
+    await openPromise;
     const data = await waitMarketStreamEvent(testApi.stream.market, 'data');
     assert.deepEqual(data.subscribeCandlesResponse?.candlesSubscriptions, [
       { figi, interval: 1, subscriptionStatus: 1 }


### PR DESCRIPTION
С учетом обсуждений в #4 и #6, а также на базе #5 добавил следующие фичи:
* отдельные методы для подписка на свечи, сделки итд, где обработчик привязывается к figi, указанным в подписке
* autoReconnect при обрыве соединения
* проверка результата при запросе подписки и выбрасывание ошибки если !== success

@BusinessDuck посмотри плз.
можем потом опубликовать в бету и проверить в бою!